### PR TITLE
travis: disable build caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
-cache: cargo
 
 install:
 - PROTOBUF_VERSION=3.3.0


### PR DESCRIPTION
This may be the cause of build timeouts.